### PR TITLE
WC dashboard: June 27 update (June 26 G/H/I results, finale + R32 opener slate, bracket A-I resolved)

### DIFF
--- a/wc/bracket.html
+++ b/wc/bracket.html
@@ -58,7 +58,7 @@
 
 <header>
   <h1>⚽ WM 2026 Spielbaum</h1>
-  <div class="sub">The knockout bracket, Round of 32 to the Final &middot; Groups A&ndash;F settled &middot; all dates 2026</div>
+  <div class="sub">The knockout bracket, Round of 32 to the Final &middot; Groups A&ndash;I settled &middot; all dates 2026</div>
   <div class="home"><a href="https://www.timwappenhans.com">&larr; timwappenhans.com</a></div>
   <nav class="nav">
     <a href="predictions.html">Predictions</a>
@@ -69,26 +69,26 @@
 </header>
 
 <div class="intro">
-  <b>How teams get here:</b> 48 teams, 12 groups of four. The top two of every group qualify directly (24 teams), and the eight best of the twelve third-placed teams fill the rest, for a 32-team Round of 32, the first in World Cup history. Four third-placed teams go home. The eight third-place slots (shown in blue) only resolve once the last group game is played on June 27, since which group fills which slot depends on which groups produce a qualifying third. <b>Groups A through F are now settled:</b> Mexico won Group A unbeaten with South Africa second on their head-to-head win over South Korea; Switzerland topped Group B ahead of co-hosts Canada; Brazil edged Morocco to top Group C on goal difference; the United States held off Türkiye's late scare to win Group D with Australia second; Germany lost to Ecuador but still won Group E on goal difference ahead of Ivory Coast, who reached the knockouts for the first time; and the Netherlands topped Group F ahead of Japan. Bosnia &amp; Herzegovina (third in B), Ecuador (third in E) and Sweden (third in F), all on four points, are very well placed in the best-third race, Bosnia already mathematically safe. They join the direct qualifiers: Mexico, the United States, Germany, Switzerland, Canada, South Africa, Brazil, Morocco, Australia, Ivory Coast, the Netherlands and Japan from Groups A&ndash;F, plus the earlier-clinched Argentina (Group J), France and Norway (Group I) and Colombia (Group K). Eliminated so far: Jordan, Panama, Uzbekistan, Tunisia, Iraq, Senegal, Haiti, Qatar, Czechia, Curaçao and Türkiye, with Scotland (third in C), South Korea (third in A) and Paraguay (third in D) left waiting on the best-third math. The bracket pairings stay provisional until the groups are settled on June 27.
+  <b>How teams get here:</b> 48 teams, 12 groups of four. The top two of every group qualify directly (24 teams), and the eight best of the twelve third-placed teams fill the rest, for a 32-team Round of 32, the first in World Cup history. Four third-placed teams go home. The eight third-place slots (shown in blue) only resolve once the last group games are played on June 27, since which group fills which slot depends on which groups produce a qualifying third. <b>Groups A through I are now settled,</b> and their winners and runners-up are filled in below: Mexico and South Africa (A), Switzerland and Canada (B), Brazil and Morocco (C), the United States and Australia (D), Germany and Ivory Coast (E), the Netherlands and Japan (F), Belgium and Egypt (G), Spain and Cape Verde (H), and France and Norway (I). Cape Verde, the smallest nation ever to reach a World Cup knockout round, and Belgium, who pipped Egypt to the top of Group G on the last night, are the newest qualifiers. In the best-third race, Ecuador (E), Sweden (F), Bosnia &amp; Herzegovina (B) and Paraguay (D) hold the four spots on four points, while Senegal (I), Iran (G), South Korea (A) and Scotland (C) fill the rest on three but can still be bumped by the thirds from Groups J, K and L. Only those three groups remain, finishing late on June 27: Argentina have won Group J with Austria and Algeria fighting for second; Colombia and Portugal are both through from Group K; and England, Ghana and Croatia chase the two places in Group L. The first knockout tie, M73 between runners-up South Africa and Canada, is already set for June 28 in Los Angeles; the rest of the bracket locks once the final eight third-placed teams are confirmed.
 </div>
 
 <div class="daybar"><h2>Round of 32 · June 28 to July 3</h2></div>
-<div class="bx"><span class="mno">M73</span><span class="slot">Runner-up A <span class="vs">vs</span> Runner-up B</span><span class="info">Jun 28 · Los Angeles</span></div>
-<div class="bx"><span class="mno">M74</span><span class="slot">Winner E <span class="vs">vs</span> <span class="third">3rd A/B/C/D/F</span></span><span class="info">Jun 29 · Boston</span></div>
-<div class="bx"><span class="mno">M75</span><span class="slot">Winner F <span class="vs">vs</span> Runner-up C</span><span class="info">Jun 29 · Monterrey</span></div>
-<div class="bx"><span class="mno">M76</span><span class="slot">Winner C <span class="vs">vs</span> Runner-up F</span><span class="info">Jun 29 · Houston</span></div>
-<div class="bx"><span class="mno">M77</span><span class="slot">Winner I <span class="vs">vs</span> <span class="third">3rd C/D/F/G/H</span></span><span class="info">Jun 30 · New York NJ</span></div>
-<div class="bx"><span class="mno">M78</span><span class="slot">Runner-up E <span class="vs">vs</span> Runner-up I</span><span class="info">Jun 30 · Dallas</span></div>
-<div class="bx"><span class="mno">M79</span><span class="slot">Winner A <span class="vs">vs</span> <span class="third">3rd C/E/F/H/I</span></span><span class="info">Jun 30 · Mexico City</span></div>
+<div class="bx"><span class="mno">M73</span><span class="slot">South Africa <span class="vs">vs</span> Canada</span><span class="info">Jun 28 · Los Angeles</span></div>
+<div class="bx"><span class="mno">M74</span><span class="slot">Germany <span class="vs">vs</span> <span class="third">3rd A/B/C/D/F</span></span><span class="info">Jun 29 · Boston</span></div>
+<div class="bx"><span class="mno">M75</span><span class="slot">Netherlands <span class="vs">vs</span> Morocco</span><span class="info">Jun 29 · Monterrey</span></div>
+<div class="bx"><span class="mno">M76</span><span class="slot">Brazil <span class="vs">vs</span> Japan</span><span class="info">Jun 29 · Houston</span></div>
+<div class="bx"><span class="mno">M77</span><span class="slot">France <span class="vs">vs</span> <span class="third">3rd C/D/F/G/H</span></span><span class="info">Jun 30 · New York NJ</span></div>
+<div class="bx"><span class="mno">M78</span><span class="slot">Ivory Coast <span class="vs">vs</span> Norway</span><span class="info">Jun 30 · Dallas</span></div>
+<div class="bx"><span class="mno">M79</span><span class="slot">Mexico <span class="vs">vs</span> <span class="third">3rd C/E/F/H/I</span></span><span class="info">Jun 30 · Mexico City</span></div>
 <div class="bx"><span class="mno">M80</span><span class="slot">Winner L <span class="vs">vs</span> <span class="third">3rd E/H/I/J/K</span></span><span class="info">Jul 1 · Atlanta</span></div>
-<div class="bx"><span class="mno">M81</span><span class="slot">Winner D <span class="vs">vs</span> <span class="third">3rd B/E/F/I/J</span></span><span class="info">Jul 1 · San Francisco Bay</span></div>
-<div class="bx"><span class="mno">M82</span><span class="slot">Winner G <span class="vs">vs</span> <span class="third">3rd A/E/H/I/J</span></span><span class="info">Jul 1 · Seattle</span></div>
+<div class="bx"><span class="mno">M81</span><span class="slot">United States <span class="vs">vs</span> <span class="third">3rd B/E/F/I/J</span></span><span class="info">Jul 1 · San Francisco Bay</span></div>
+<div class="bx"><span class="mno">M82</span><span class="slot">Belgium <span class="vs">vs</span> <span class="third">3rd A/E/H/I/J</span></span><span class="info">Jul 1 · Seattle</span></div>
 <div class="bx"><span class="mno">M83</span><span class="slot">Runner-up K <span class="vs">vs</span> Runner-up L</span><span class="info">Jul 2 · Toronto</span></div>
-<div class="bx"><span class="mno">M84</span><span class="slot">Winner H <span class="vs">vs</span> Runner-up J</span><span class="info">Jul 2 · Los Angeles</span></div>
-<div class="bx"><span class="mno">M85</span><span class="slot">Winner B <span class="vs">vs</span> <span class="third">3rd E/F/G/I/J</span></span><span class="info">Jul 2 · Vancouver</span></div>
-<div class="bx"><span class="mno">M86</span><span class="slot">Winner J <span class="vs">vs</span> Runner-up H</span><span class="info">Jul 3 · Miami</span></div>
+<div class="bx"><span class="mno">M84</span><span class="slot">Spain <span class="vs">vs</span> Runner-up J</span><span class="info">Jul 2 · Los Angeles</span></div>
+<div class="bx"><span class="mno">M85</span><span class="slot">Switzerland <span class="vs">vs</span> <span class="third">3rd E/F/G/I/J</span></span><span class="info">Jul 2 · Vancouver</span></div>
+<div class="bx"><span class="mno">M86</span><span class="slot">Winner J <span class="vs">vs</span> Cape Verde</span><span class="info">Jul 3 · Miami</span></div>
 <div class="bx"><span class="mno">M87</span><span class="slot">Winner K <span class="vs">vs</span> <span class="third">3rd D/E/I/J/L</span></span><span class="info">Jul 3 · Kansas City</span></div>
-<div class="bx"><span class="mno">M88</span><span class="slot">Runner-up D <span class="vs">vs</span> Runner-up G</span><span class="info">Jul 3 · Dallas</span></div>
+<div class="bx"><span class="mno">M88</span><span class="slot">Australia <span class="vs">vs</span> Egypt</span><span class="info">Jul 3 · Dallas</span></div>
 
 <div class="daybar"><h2>Round of 16 · July 4 to 7</h2></div>
 <div class="half">Top half</div>

--- a/wc/predictions.html
+++ b/wc/predictions.html
@@ -143,7 +143,7 @@
 
 <header>
   <h1>⚽ WM 2026 Dashboard</h1>
-  <div class="sub">Group stage, matchday-3 finale June 26&ndash;27 &middot; all kickoffs Berlin time &middot; data pulled Fri June 26, morning</div>
+  <div class="sub">Group-stage finale (Groups J, K, L) and the first Round-of-32 tie &middot; June 27&ndash;28 &middot; all kickoffs Berlin time &middot; data pulled Sat June 27, morning</div>
   <div class="home"><a href="https://www.timwappenhans.com">&larr; timwappenhans.com</a></div>
   <nav class="nav">
     <a href="predictions.html" class="active">Predictions</a>
@@ -154,274 +154,32 @@
 </header>
 
 <div class="recap">
-  <b>The June 25 slate (Groups E, F and D), my guesses vs results:</b>
-  Germany win &rarr; <span class="miss">2-1 Ecuador, X</span> &middot;
-  Ivory Coast 3-0 &rarr; <span class="hit">0-2 Ivory Coast, W</span> &middot;
-  Japan 2-1 &rarr; <span class="miss">1-1 draw, X</span> &middot;
-  Netherlands 0-3 &rarr; <span class="hit">1-3 Netherlands, W</span> &middot;
-  Türkiye 1-1 USA &rarr; <span class="miss">3-2 Türkiye, X</span> &middot;
-  Paraguay 1-1 Australia &rarr; <span class="hit">0-0 draw, W</span>.
-  Three correct from six on a slate full of dead rubbers and rotation. Germany rested heavily and lost 2-1 to Ecuador (Leroy Sané scored after two minutes) yet still won Group E on goal difference, while Ivory Coast's Nicolas Pépé brace beat Curaçao to send the Elephants into the knockouts for the first time. My Japan call was the bad one: I expected a Japan win, but Daizen Maeda's opener was cancelled by Anthony Elanga and a 1-1 sent both Japan and Sweden through. The USA, already group winners, lost a wild one to Türkiye on Kaan Ayhan's stoppage-time winner, beating my draw. The two draws I did get right were the Paraguay-Australia stalemate, which sent Australia through on goal difference, and the Netherlands romp I called comfortably. Across the tournament my record now stands at <b>30 correct winners from 52</b>.
+  <b>The June 26 slate (Groups I, H and G), my guesses vs results:</b>
+  Norway 1-2 France &rarr; <span class="hit">1-4 France, W</span> &middot;
+  Senegal 3-0 Iraq &rarr; <span class="hit">5-0 Senegal, W</span> &middot;
+  Uruguay 1-2 Spain &rarr; <span class="hit">0-1 Spain, W</span> &middot;
+  Cape Verde 2-1 &rarr; <span class="miss">0-0 draw, X</span> &middot;
+  Egypt 1-1 Iran &rarr; <span class="hit">1-1 draw, W</span> &middot;
+  New Zealand 1-2 Belgium &rarr; <span class="hit">1-5 Belgium, W</span>.
+  Five correct from six, my best slate of the tournament. France romped to the top of Group I behind Ousmane Dembélé's first-half hat-trick, and Norway went through second despite a missed penalty. Senegal's 5-0 demolition of ten-man Iraq, the biggest World Cup win ever by an African nation, grabbed them a best-third place. Spain edged Uruguay 1-0 to send the two-time champions home, and Cape Verde's goalless draw with Saudi Arabia made them the smallest nation ever to reach the knockouts, the one result that beat me. Belgium's 5-1 rout of New Zealand vaulted them above Egypt to win Group G, while Iran, held 1-1, had a stoppage-time winner ruled out by VAR and slipped to third. Across the tournament my record now stands at <b>35 correct winners from 58</b>.
   <br><br>
-  <b>The final group round wraps up:</b> Groups G, H and I settle their places tonight into Saturday morning (slate below, unchanged from yesterday), then Groups L, K and J close the group stage Saturday evening into Sunday morning. Both group games in each group kick off simultaneously. The two slates are below.
-</div>
-
-<div class="daybar"><h2>Friday, June 26 → Saturday morning</h2></div>
-
-<!-- Norway vs France -->
-<div class="match">
-  <div class="meta"><span>Group I &middot; Gillette Stadium, Boston</span><span>Fri 21:00</span></div>
-  <div class="scoreline">
-    <div class="team home"><span>Norway</span><span class="flag">🇳🇴</span></div>
-    <div><div class="pred">1 : 2</div><div class="predlabel">My guess</div></div>
-    <div class="team"><span class="flag">🇫🇷</span><span>France</span></div>
-  </div>
-  <div class="odds">Market: France <b>~61%</b> &middot; draw <b>~24%</b> &middot; Norway <b>~21%</b> (bet365; FRA -154, NOR +375)</div>
-  <div class="rationale">France are favorites and need only a draw to top the group, with Deschamps away and rotation likely, but Norway must win to finish first and Haaland is flying. A 1-2 backs France's quality in a genuine contest; Norway's need and form make the draw live value.</div>
-  <div class="teaminfo">
-    <div class="col home">
-      <div class="forms">
-        <span class="chip w" title="3-2 vs Senegal, Jun 22 (World Cup)">W</span><span class="chip w" title="4-1 vs Iraq, Jun 16 (World Cup)">W</span><span class="chip d" title="1-1 vs Morocco, Jun 7 (friendly)">D</span><span class="chip w" title="3-1 vs Sweden, Jun 1 (friendly)">W</span><span class="chip w" title="4-1 vs Italy, Nov 16 2025 (World Cup qualifying)">W</span>
-      </div>
-      <ul>
-        <li>Through to the round of 32 on six points and a plus-four difference; must win to top Group I, as a draw hands France first on goal difference</li>
-        <li class="inj">No suspensions or fresh injuries reported; St&aring;le Solbakken can field a full-strength side</li>
-        <li>Coached by St&aring;le Solbakken; Erling Haaland has four goals in two games, with captain Martin &Oslash;degaard and Antonio Nusa in support</li>
-        <li>Qualified by winning their European group with a perfect record, finishing with a 4-1 rout of Italy</li>
-        <li class="triv">This is Norway's first World Cup since 1998, so Haaland had never scored at one until this month</li>
-      </ul>
-    </div>
-    <div class="col">
-      <div class="forms">
-        <span class="chip w" title="3-0 vs Iraq, Jun 22 (World Cup)">W</span><span class="chip w" title="3-1 vs Senegal, Jun 16 (World Cup)">W</span><span class="chip w" title="3-1 vs Northern Ireland, Jun 8 (friendly)">W</span><span class="chip l" title="1-2 vs Ivory Coast, Jun 4 (friendly)">L</span><span class="chip w" title="3-1 vs Colombia, Mar 29 (friendly)">W</span>
-      </div>
-      <ul>
-        <li>Through on six points and top of the group on goal difference (+5); a draw is enough to secure first place</li>
-        <li class="inj">No player suspensions, but head coach Didier Deschamps is away following the death of his mother, with assistant Guy St&eacute;phan in charge</li>
-        <li>Coached by Didier Deschamps; Kylian Mbapp&eacute;, now France's all-time top scorer, leads with Michael Olise and Bradley Barcola</li>
-        <li>Have won four in a row, including both group games by 3-0 and 3-1</li>
-        <li class="triv">Mbapp&eacute; passed Olivier Giroud as France's all-time leading scorer with a late brace against Senegal, reaching 58 goals</li>
-      </ul>
-    </div>
-  </div>
-</div>
-
-<!-- Senegal vs Iraq -->
-<div class="match">
-  <div class="meta"><span>Group I &middot; BMO Field, Toronto</span><span>Fri 21:00</span></div>
-  <div class="scoreline">
-    <div class="team home"><span>Senegal</span><span class="flag">🇸🇳</span></div>
-    <div><div class="pred">3 : 0</div><div class="predlabel">My guess</div></div>
-    <div class="team"><span class="flag">🇮🇶</span><span>Iraq</span></div>
-  </div>
-  <div class="odds">Market: Senegal <b>~82%</b> &middot; draw <b>~17%</b> &middot; Iraq <b>~8%</b> (bet365; SEN -450, IRQ +1200)</div>
-  <div class="rationale">Senegal are heavy favorites and, chasing goals for a slim best-third place, will push despite losing goalkeeper Mendy, while Iraq have leaked seven in two games. A 3-0 backs a comfortable Senegal win in line with the market.</div>
-  <div class="teaminfo">
-    <div class="col home">
-      <div class="forms">
-        <span class="chip l" title="2-3 vs Norway, Jun 22 (World Cup)">L</span><span class="chip l" title="1-3 vs France, Jun 16 (World Cup)">L</span><span class="chip l" title="2-3 vs USA, Jun 2026 (friendly)">L</span><span class="chip d" title="0-0 vs Saudi Arabia, Jun 2026 (friendly)">D</span><span class="chip w" title="3-1 vs Gambia, Mar 2026 (friendly)">W</span>
-      </div>
-      <ul>
-        <li>On zero points and out of the top two, but a big win keeps a faint best-third hope alive</li>
-        <li class="inj">First-choice goalkeeper &Eacute;douard Mendy is out with a knee injury suffered against Norway, with Mory Diaw set to deputize</li>
-        <li>Coached by Pape Thiaw; Sadio Man&eacute;, Isma&iuml;la Sarr, who scored twice against Norway, and Nicolas Jackson lead the attack</li>
-        <li>Lost both group games after conceding late goals each time</li>
-        <li class="triv">Senegal won the 2025 Africa Cup of Nations on the pitch but were later stripped of the title by CAF, a ruling they are appealing</li>
-      </ul>
-    </div>
-    <div class="col">
-      <div class="forms">
-        <span class="chip l" title="0-3 vs France, Jun 22 (World Cup)">L</span><span class="chip l" title="1-4 vs Norway, Jun 16 (World Cup)">L</span><span class="chip l" title="0-2 vs Venezuela, Jun 2026 (friendly)">L</span><span class="chip d" title="1-1 vs Spain, Jun 4 (friendly)">D</span><span class="chip w" title="1-0 vs Andorra, May 2026 (friendly)">W</span>
-      </div>
-      <ul>
-        <li>Bottom on zero points with a minus-six difference; only a heavy win offers any best-third lifeline</li>
-        <li class="inj">Striker Aymen Hussein, their only scorer of the finals, limped off against France and is a fitness doubt</li>
-        <li>Coached by Australian Graham Arnold; Zidane Iqbal and Amir Al-Ammari are the creative hub</li>
-        <li>Conceded seven goals across the two group games</li>
-        <li class="triv">This is Iraq's first World Cup in 40 years, since Mexico 1986; they remain the 2007 Asian Cup champions</li>
-      </ul>
-    </div>
-  </div>
-</div>
-
-<!-- Uruguay vs Spain -->
-<div class="match">
-  <div class="meta"><span>Group H &middot; Estadio Akron, Guadalajara</span><span>Sat 02:00</span></div>
-  <div class="scoreline">
-    <div class="team home"><span>Uruguay</span><span class="flag">🇺🇾</span></div>
-    <div><div class="pred">1 : 2</div><div class="predlabel">My guess</div></div>
-    <div class="team"><span class="flag">🇪🇸</span><span>Spain</span></div>
-  </div>
-  <div class="odds">Market: Spain <b>~67%</b> &middot; draw <b>~23%</b> &middot; Uruguay <b>~14%</b> (bet365; ESP -209, URU +600)</div>
-  <div class="rationale">Spain are clear favorites and, even with likely rotation, hold a wide quality edge over a Uruguay side missing Ar&aacute;ujo and de Arrascaeta. A 1-2 backs Spain while crediting Uruguay, who need only a point, a goal of their own.</div>
-  <div class="teaminfo">
-    <div class="col home">
-      <div class="forms">
-        <span class="chip d" title="2-2 vs Cape Verde, Jun 21 (World Cup)">D</span><span class="chip d" title="1-1 vs Saudi Arabia, Jun 15 (World Cup)">D</span><span class="chip d" title="0-0 vs Algeria, Mar 31 (friendly)">D</span><span class="chip l" title="0-1 vs England, Mar 27 (friendly)">L</span><span class="chip l" title="1-5 vs USA, Nov 18 2025 (friendly)">L</span>
-      </div>
-      <ul>
-        <li>Second on two points; a draw very likely secures a knockout place, while a win would take the group</li>
-        <li class="inj">Defender Ronald Ar&aacute;ujo and playmaker Giorgian de Arrascaeta are both out with calf injuries, a double blow</li>
-        <li>Coached by Marcelo Bielsa; Federico Valverde, Darwin N&uacute;&ntilde;ez and Maxi Ar&aacute;ujo lead, with Fernando Muslera in goal</li>
-        <li>Have drawn every game since a heavy November loss without beating anyone in that run</li>
-        <li class="triv">Uruguay won the very first World Cup, as hosts in 1930, and remain one of the most decorated nations in the tournament's history</li>
-      </ul>
-    </div>
-    <div class="col">
-      <div class="forms">
-        <span class="chip w" title="4-0 vs Saudi Arabia, Jun 21 (World Cup)">W</span><span class="chip d" title="0-0 vs Cape Verde, Jun 15 (World Cup)">D</span><span class="chip w" title="3-1 vs Peru, Jun 9 (friendly)">W</span><span class="chip d" title="1-1 vs Iraq, Jun 4 (friendly)">D</span><span class="chip d" title="0-0 vs Egypt, Mar 31 (friendly)">D</span>
-      </div>
-      <ul>
-        <li>Top of Group H on four points (+4); a win or a draw guarantees first place</li>
-        <li class="inj">No injuries or suspensions reported, and with first place near-secured Luis de la Fuente may rotate</li>
-        <li>Coached by Luis de la Fuente; Lamine Yamal, Nico Williams, Dani Olmo and captain Rodri headline</li>
-        <li>Routed Saudi Arabia 4-0 after a goalless opener against Cape Verde</li>
-        <li class="triv">Spain are the reigning European champions, having won UEFA Euro 2024</li>
-      </ul>
-    </div>
-  </div>
-</div>
-
-<!-- Cape Verde vs Saudi Arabia -->
-<div class="match">
-  <div class="meta"><span>Group H &middot; NRG Stadium, Houston</span><span>Sat 02:00</span></div>
-  <div class="scoreline">
-    <div class="team home"><span>Cape Verde</span><span class="flag">🇨🇻</span></div>
-    <div><div class="pred">2 : 1</div><div class="predlabel">My guess</div></div>
-    <div class="team"><span class="flag">🇸🇦</span><span>Saudi Arabia</span></div>
-  </div>
-  <div class="odds">Market: Cape Verde <b>~42%</b> &middot; Saudi Arabia <b>~35%</b> &middot; draw <b>~29%</b> (bet365; CPV +135, KSA +190)</div>
-  <div class="rationale">A near coin-flip in which both sides must chase the win to advance, with Cape Verde the steadier after holding Spain and Uruguay. A 2-1 backs the home edge in what should be an open game.</div>
-  <div class="teaminfo">
-    <div class="col home">
-      <div class="forms">
-        <span class="chip d" title="2-2 vs Uruguay, Jun 21 (World Cup)">D</span><span class="chip d" title="0-0 vs Spain, Jun 15 (World Cup)">D</span><span class="chip w" title="3-0 vs Serbia, May 31 (friendly)">W</span><span class="chip d" title="1-1 vs Finland, Mar 2026 (friendly, won on penalties)">D</span><span class="chip l" title="2-4 vs Chile, Mar 2026 (friendly)">L</span>
-      </div>
-      <ul>
-        <li>Third on two points; a win secures a first-ever knockout place, while a draw would need results elsewhere</li>
-        <li class="inj">Midfielder Sidny Lopes is suspended after a second booking against Uruguay; Telmo Arcanjo and Jovane Cabral are doubts</li>
-        <li>Coached by Pedro "Bubista" Brito; goalkeeper Vozinha, who shut out Spain, and captain Ryan Mendes are central</li>
-        <li>Held Spain to a goalless draw before twice coming from behind to draw with Uruguay</li>
-        <li class="triv">On their World Cup debut, Cape Verde, with a population around 525,000, are the smallest country by area ever to reach the men's finals</li>
-      </ul>
-    </div>
-    <div class="col">
-      <div class="forms">
-        <span class="chip l" title="0-4 vs Spain, Jun 21 (World Cup)">L</span><span class="chip d" title="1-1 vs Uruguay, Jun 15 (World Cup)">D</span><span class="chip d" title="0-0 vs Senegal, Jun 2026 (friendly)">D</span><span class="chip w" title="3-0 vs Puerto Rico, 2026 (friendly)">W</span><span class="chip l" title="1-2 vs Ecuador, 2026 (friendly)">L</span>
-      </div>
-      <ul>
-        <li>Bottom on a single point after a 4-0 loss to Spain; must win to keep alive a faint best-third hope</li>
-        <li class="inj">No fresh injuries or suspensions confirmed for the match</li>
-        <li>Coached by Georgios Donis; captain Salem Al-Dawsari leads, with Abdulelah Al-Amri the scorer against Uruguay</li>
-        <li>Bounced between a draw with Uruguay and a heavy defeat to Spain</li>
-        <li class="triv">Saudi Arabia beat eventual champions Argentina 2-1 at the 2022 World Cup, one of the great tournament upsets</li>
-      </ul>
-    </div>
-  </div>
-</div>
-
-<!-- Egypt vs Iran -->
-<div class="match">
-  <div class="meta"><span>Group G &middot; Lumen Field, Seattle</span><span>Sat 05:00</span></div>
-  <div class="scoreline">
-    <div class="team home"><span>Egypt</span><span class="flag">🇪🇬</span></div>
-    <div><div class="pred">1 : 1</div><div class="predlabel">My guess</div></div>
-    <div class="team"><span class="flag">🇮🇷</span><span>Iran</span></div>
-  </div>
-  <div class="odds">Market: Egypt <b>~41%</b> &middot; draw <b>~33%</b> &middot; Iran <b>~26%</b> (bet365; EGY +140, IRN +260)</div>
-  <div class="rationale">A draw suits Egypt, who would top the group, and could be enough for Iran too, which is why the market prices the draw unusually short. A 1-1 leans on that mutual sufficiency in a likely cagey game rather than backing the slim favorite.</div>
-  <div class="teaminfo">
-    <div class="col home">
-      <div class="forms">
-        <span class="chip w" title="3-1 vs New Zealand, Jun 21 (World Cup)">W</span><span class="chip d" title="1-1 vs Belgium, Jun 15 (World Cup)">D</span><span class="chip l" title="1-2 vs Brazil, Jun 6 (friendly)">L</span><span class="chip w" title="1-0 vs Russia, May 28 (friendly)">W</span><span class="chip d" title="0-0 vs Spain, Mar 31 (friendly)">D</span>
-      </div>
-      <ul>
-        <li>Top of Group G on four points; a draw guarantees first place and a spot in the round of 32</li>
-        <li class="inj">No injuries or suspensions reported; Hossam Hassan has a settled side</li>
-        <li>Coached by Hossam Hassan; Mohamed Salah, chasing Egypt's scoring records, leads with Omar Marmoush and Trezeguet</li>
-        <li>Beat New Zealand after opening with a draw against Belgium, conceding just twice</li>
-        <li class="triv">Egypt have never advanced past the World Cup group stage in three previous appearances, so a point here would be historic</li>
-      </ul>
-    </div>
-    <div class="col">
-      <div class="forms">
-        <span class="chip d" title="0-0 vs Belgium, Jun 21 (World Cup)">D</span><span class="chip d" title="2-2 vs New Zealand, Jun 15 (World Cup)">D</span><span class="chip w" title="2-0 vs Mali, Jun 4 (friendly)">W</span><span class="chip w" title="3-1 vs Gambia, May 29 (friendly)">W</span><span class="chip w" title="5-0 vs Costa Rica, Mar 31 (friendly)">W</span>
-      </div>
-      <ul>
-        <li>Second on two points; a win would likely secure a knockout place, and a draw could still be enough as a best third</li>
-        <li class="inj">Several players cramped in the heat in earlier games; no suspensions are reported, with Sardar Azmoun left out of the squad</li>
-        <li>Coached by Amir Ghalenoei; captain Mehdi Taremi leads the line and won the foul that had Belgium's Ngoy sent off</li>
-        <li>Drew their first two games and are unbeaten but still chasing a first win</li>
-        <li class="triv">Iran arrived on a run of three straight wins in warm-up friendlies, including a 5-0 rout of Costa Rica</li>
-      </ul>
-    </div>
-  </div>
-</div>
-
-<!-- New Zealand vs Belgium -->
-<div class="match">
-  <div class="meta"><span>Group G &middot; BC Place, Vancouver</span><span>Sat 05:00</span></div>
-  <div class="scoreline">
-    <div class="team home"><span>New Zealand</span><span class="flag">🇳🇿</span></div>
-    <div><div class="pred">1 : 2</div><div class="predlabel">My guess</div></div>
-    <div class="team"><span class="flag">🇧🇪</span><span>Belgium</span></div>
-  </div>
-  <div class="odds">Market: Belgium <b>~82%</b> &middot; draw <b>~13%</b> &middot; New Zealand <b>~7%</b> (bet365; BEL -500, NZL +1000)</div>
-  <div class="rationale">Belgium are overwhelming favorites and must win, so they should finally press despite a wasteful start, while New Zealand have leaked five goals in two games. A 1-2 backs Belgium but credits the All Whites, who have scored in both games, a goal.</div>
-  <div class="teaminfo">
-    <div class="col home">
-      <div class="forms">
-        <span class="chip l" title="1-3 vs Egypt, Jun 21 (World Cup)">L</span><span class="chip d" title="2-2 vs Iran, Jun 15 (World Cup)">D</span><span class="chip l" title="0-1 vs England, Jun 6 (friendly)">L</span><span class="chip l" title="0-4 vs Haiti, Jun 2 (friendly)">L</span><span class="chip w" title="4-1 vs Chile, Mar 30 (friendly)">W</span>
-      </div>
-      <ul>
-        <li>Bottom on a single point; must beat Belgium and hope for help elsewhere to chase a best-third spot</li>
-        <li class="inj">No suspensions reported; Darren Bazeley has his squad available</li>
-        <li>Coached by Darren Bazeley; Chris Wood leads the line, with Elijah Just, scorer of a brace against Iran, in support</li>
-        <li>Earned a point against Iran before losing to Egypt</li>
-        <li class="triv">New Zealand went unbeaten at the 2010 World Cup with three draws yet still have never won a match at the finals</li>
-      </ul>
-    </div>
-    <div class="col">
-      <div class="forms">
-        <span class="chip d" title="0-0 vs Iran, Jun 21 (World Cup)">D</span><span class="chip d" title="1-1 vs Egypt, Jun 15 (World Cup)">D</span><span class="chip w" title="5-0 vs Tunisia, Jun 6 (friendly)">W</span><span class="chip w" title="2-0 vs Croatia, Jun 2 (friendly)">W</span><span class="chip d" title="1-1 vs Mexico, Mar 31 (friendly)">D</span>
-      </div>
-      <ul>
-        <li>Third on two points and behind Iran on goals scored; a win is needed to be sure of advancing</li>
-        <li class="inj">Defender Nathan Ngoy is suspended after his red card against Iran, with J&eacute;r&eacute;my Doku back in the squad</li>
-        <li>Coached by Rudi Garcia; Kevin De Bruyne, Romelu Lukaku and Leandro Trossard carry the attack</li>
-        <li>Have drawn both games and scored just once, held to a goalless draw by ten-man Iran's keeper</li>
-        <li class="triv">Belgium's golden generation finished third at the 2018 World Cup but have never won a major trophy</li>
-      </ul>
-    </div>
-  </div>
+  <b>The group stage signs off, and the knockouts begin:</b> Groups L, K and J close the first round tonight into Sunday morning, the two games in each group kicking off together. Then the Round of 32 opens Sunday evening with a single tie, runner-up against runner-up, between co-hosts Canada and South Africa in Los Angeles. Both slates are below.
 </div>
 
 <div class="daybar"><h2>Saturday, June 27 → Sunday morning</h2></div>
 
-<!-- England vs Panama -->
+<!-- Panama vs England -->
 <div class="match">
   <div class="meta"><span>Group L &middot; MetLife Stadium, New York/New Jersey</span><span>Sat 23:00</span></div>
   <div class="scoreline">
-    <div class="team home"><span>England</span><span class="flag">🏴󠁧󠁢󠁥󠁮󠁧󠁿</span></div>
-    <div><div class="pred">2 : 0</div><div class="predlabel">My guess</div></div>
-    <div class="team"><span class="flag">🇵🇦</span><span>Panama</span></div>
+    <div class="team home"><span>Panama</span><span class="flag">🇵🇦</span></div>
+    <div><div class="pred">0 : 2</div><div class="predlabel">My guess</div></div>
+    <div class="team"><span class="flag">🏴󠁧󠁢󠁥󠁮󠁧󠁿</span><span>England</span></div>
   </div>
-  <div class="odds">Market: England <b>~86%</b> &middot; draw <b>~12%</b> &middot; Panama <b>~6%</b> (BetMGM; ENG -600, PAN +1700)</div>
-  <div class="rationale">England top the group with a win and are overwhelming favorites against a winless, eliminated Panama. Tuchel may rotate and manage Declan Rice's booking, but the gulf in quality points to a comfortable margin, and a 2-0 sits with the heavy market.</div>
+  <div class="odds">Market: England <b>~88%</b> &middot; draw <b>~9%</b> &middot; Panama <b>~8%</b> (bet365; ENG 1.13, PAN +1200)</div>
+  <div class="rationale">England need only a point to win the group and are overwhelming favorites against a winless, eliminated Panama still yet to score. Tuchel will rotate, with Reece James and Tino Livramento now ruled out, but the gulf in quality still points to a comfortable England margin, so a 2-0 sits with the heavy market.</div>
   <div class="teaminfo">
     <div class="col home">
-      <div class="forms">
-        <span class="chip d" title="0-0 vs Ghana, Jun 23 (World Cup)">D</span><span class="chip w" title="4-2 vs Croatia, Jun 15 (World Cup)">W</span><span class="chip w" title="3-0 vs Costa Rica, Jun 10 (friendly)">W</span><span class="chip w" title="1-0 vs New Zealand, Jun 6 (friendly)">W</span><span class="chip l" title="0-1 vs Japan, Mar 31 (friendly)">L</span>
-      </div>
-      <ul>
-        <li>Lead Group L on four points (+2); a win guarantees top spot and the round of 32</li>
-        <li class="inj">Bukayo Saka is managing Achilles tendinitis and Marcus Rashford a hamstring, with Reece James a fitness doubt; Declan Rice is one booking from a knockout suspension, so Tuchel may rotate</li>
-        <li>Coached by Thomas Tuchel; captain Harry Kane leads the line with Jude Bellingham and Saka</li>
-        <li>Held to a flat 0-0 by Ghana after opening with a 4-2 win over Croatia</li>
-        <li class="triv">England reached the semifinals or better at the last two World Cups but have not won the trophy since 1966</li>
-      </ul>
-    </div>
-    <div class="col">
       <div class="forms">
         <span class="chip l" title="0-1 vs Croatia, Jun 23 (World Cup)">L</span><span class="chip l" title="0-1 vs Ghana, Jun 17 (World Cup)">L</span><span class="chip d" title="1-1 vs Bosnia & Herzegovina, Jun 2026 (friendly)">D</span><span class="chip w" title="4-2 vs Dominican Republic, Jun 4 (friendly)">W</span><span class="chip l" title="2-6 vs Brazil, 2026 (friendly)">L</span>
       </div>
@@ -431,6 +189,18 @@
         <li>Coached by Dane Thomas Christiansen; Adalberto Carrasquilla, José Fajardo and Ismael Díaz are the key men</li>
         <li>Lost 0-1 to both Ghana and Croatia, undone by late goals each time</li>
         <li class="triv">Panama have failed to score a single goal across the entire group stage</li>
+      </ul>
+    </div>
+    <div class="col">
+      <div class="forms">
+        <span class="chip d" title="0-0 vs Ghana, Jun 23 (World Cup)">D</span><span class="chip w" title="4-2 vs Croatia, Jun 15 (World Cup)">W</span><span class="chip w" title="3-0 vs Costa Rica, Jun 10 (friendly)">W</span><span class="chip w" title="1-0 vs New Zealand, Jun 6 (friendly)">W</span><span class="chip l" title="0-1 vs Japan, Mar 31 (friendly)">L</span>
+      </div>
+      <ul>
+        <li>Lead Group L on four points (+2); a point against Panama guarantees top spot and the round of 32</li>
+        <li class="inj">Reece James (hamstring) and Tino Livramento (calf) are out, with Trevoh Chalobah called up; Bukayo Saka (Achilles) and Marcus Rashford (hamstring) are being managed, and Declan Rice is one booking from a suspension, so Tuchel rotates</li>
+        <li>Coached by Thomas Tuchel; captain Harry Kane leads the line with Jude Bellingham and Saka</li>
+        <li>Held to a flat 0-0 by Ghana after opening with a 4-2 win over Croatia</li>
+        <li class="triv">England reached the semifinals or better at the last two World Cups but have not won the trophy since 1966</li>
       </ul>
     </div>
   </div>
@@ -465,7 +235,7 @@
       </div>
       <ul>
         <li>Second on four points (+1); a draw would almost certainly send the Black Stars through</li>
-        <li class="inj">No fresh absentees reported, though Iñaki Williams carries a booking into the game</li>
+        <li class="inj">Goalkeeper Lawrence Ati-Zigi is out for the tournament (groin), with Benjamin Asare keeping; Caleb Yirenkyi and Iñaki Williams are each one booking from a suspension</li>
         <li>Coached by Carlos Queiroz, at a record fifth World Cup as a head coach; Mohammed Kudus, Williams and Thomas Partey lead</li>
         <li>Drew 0-0 with England after edging Panama on a stoppage-time winner</li>
         <li class="triv">Ghana are four-time African champions but have not won a World Cup knockout tie since reaching the quarterfinals in 2010</li>
@@ -503,7 +273,7 @@
       </div>
       <ul>
         <li>Second on four points (+5); a draw guarantees a knockout place and a win takes the group</li>
-        <li class="inj">No injuries or suspensions confirmed; Roberto Martínez may rotate with qualification near-secure</li>
+        <li class="inj">Defender Tomás Araújo is a doubt with a knock from the opener; Ronaldo is expected to start as Portugal chase top spot, with rotation elsewhere</li>
         <li>Coached by Roberto Martínez; captain Cristiano Ronaldo, 41, leads with Bruno Fernandes and Rafael Leão</li>
         <li>Routed Uzbekistan 5-0 after a 1-1 draw with DR Congo</li>
         <li class="triv">Ronaldo became the first man to score at six different World Cups with his brace against Uzbekistan</li>
@@ -555,11 +325,11 @@
   <div class="meta"><span>Group J &middot; AT&amp;T Stadium, Dallas</span><span>Sun 04:00</span></div>
   <div class="scoreline">
     <div class="team home"><span>Argentina</span><span class="flag">🇦🇷</span></div>
-    <div><div class="pred">2 : 0</div><div class="predlabel">My guess</div></div>
+    <div><div class="pred">2 : 1</div><div class="predlabel">My guess</div></div>
     <div class="team"><span class="flag">🇯🇴</span><span>Jordan</span></div>
   </div>
-  <div class="odds">Market: Argentina <b>~83%</b> &middot; draw <b>~13%</b> &middot; Jordan <b>~6%</b> (Oddschecker; ARG -475, JOR +1600)</div>
-  <div class="rationale">A dead rubber for group winners Argentina, who will likely rest Messi and other starters, against eliminated debutants Jordan. A 2-0 trusts Argentina's depth to win comfortably even rotated, a small step short of the market's heavier line.</div>
+  <div class="odds">Market: Argentina <b>~64%</b> &middot; draw <b>~35%</b> &middot; Jordan <b>~9%</b> (ESPN; ARG -180, JOR +1000)</div>
+  <div class="rationale">A dead rubber for group winners Argentina, who are expected to rest Messi and rotate heavily, which is why the market is unusually soft for them and prices the draw at over a third. A 2-1 still backs Argentina's depth but credits a Jordan side that scored in both their defeats.</div>
   <div class="teaminfo">
     <div class="col home">
       <div class="forms">
@@ -567,10 +337,10 @@
       </div>
       <ul>
         <li>Group J winners on six points, already into the round of 32 with first place secured</li>
-        <li class="inj">No suspensions; with top spot locked Lionel Scaloni is expected to rest Lionel Messi and other starters</li>
-        <li>Coached by Lionel Scaloni; Messi, Lautaro Martínez and Rodrigo De Paul lead the defending champions</li>
+        <li class="inj">No suspensions; with top spot locked Scaloni is expected to manage Messi's minutes and rotate, with Julián Álvarez and Nico Paz in line to feature</li>
+        <li>Coached by Lionel Scaloni; Messi, Lautaro Martínez and Rodrigo De Paul lead the defending champions, who carry an eight-game clean-sheet run</li>
         <li>Have won every game, Messi scoring a hat-trick against Algeria and a brace against Austria</li>
-        <li class="triv">Messi, 38, overtook Miroslav Klose as the all-time men's World Cup top scorer during this tournament</li>
+        <li class="triv">Messi, who turned 39 during the tournament, overtook Miroslav Klose as the all-time men's World Cup top scorer this month</li>
       </ul>
     </div>
     <div class="col">
@@ -596,8 +366,8 @@
     <div><div class="pred">1 : 1</div><div class="predlabel">My guess</div></div>
     <div class="team"><span class="flag">🇩🇿</span><span>Algeria</span></div>
   </div>
-  <div class="odds">Market: draw <b>~44%</b> &middot; Austria <b>~35%</b> &middot; Algeria <b>~25%</b> (Oddschecker/FanDuel; AUT +190, ALG +305)</div>
-  <div class="rationale">A straight shootout for second in which Austria go through with a draw on goal difference while Algeria, without the injured Amoura, must win. The market makes the draw the single likeliest outcome, so a 1-1 that sends Austria through is the market-aligned call rather than forcing a winner.</div>
+  <div class="odds">Market: draw <b>~45%</b> &middot; Austria <b>~35%</b> &middot; Algeria <b>~25%</b> (FanDuel; AUT +190, draw +120, ALG +300)</div>
+  <div class="rationale">A straight shootout for second: Austria go through with a draw on goal difference while Algeria, without the injured Amoura, must win. There is a twist, though, as the runner-up here likely draws Spain in the round of 32 and a best-third finish may bring a kinder tie, so neither side may be desperate to win. The market makes the draw the single likeliest outcome, so a 1-1 that edges Austria through is the market-aligned call.</div>
   <div class="teaminfo">
     <div class="col home">
       <div class="forms">
@@ -605,7 +375,7 @@
       </div>
       <ul>
         <li>Level on three points with Algeria; a draw sends them through second on goal difference</li>
-        <li class="inj">No suspensions reported; Konrad Laimer and Stefan Posch were booked against Argentina but are available</li>
+        <li class="inj">Paul Wanner (calf) and Stefan Posch (jaw) are doubts, while David Alaba has shaken off a knee issue; record scorer Marko Arnautović is primed for a first start of the finals</li>
         <li>Coached by Ralf Rangnick; captain David Alaba leads with Marcel Sabitzer and Marko Arnautović</li>
         <li>Beat Jordan 3-1 before a 2-0 loss to group winners Argentina</li>
         <li class="triv">This is Austria's first World Cup since France 1998</li>
@@ -626,8 +396,48 @@
   </div>
 </div>
 
+<div class="daybar"><h2>Sunday, June 28 → evening · Round of 32 opens</h2></div>
+
+<!-- South Africa vs Canada -->
+<div class="match">
+  <div class="meta"><span>Round of 32 (M73, Runners-up A &amp; B) &middot; SoFi Stadium, Los Angeles</span><span>Sun 21:00</span></div>
+  <div class="scoreline">
+    <div class="team home"><span>South Africa</span><span class="flag">🇿🇦</span></div>
+    <div><div class="pred">0 : 1</div><div class="predlabel">My guess</div></div>
+    <div class="team"><span class="flag">🇨🇦</span><span>Canada</span></div>
+  </div>
+  <div class="odds">Market: Canada <b>~58%</b> &middot; draw <b>~26%</b> &middot; South Africa <b>~18%</b> (bet365; CAN -140, RSA +460)</div>
+  <div class="rationale">The knockouts open with a runner-up derby. Co-hosts Canada, unbeaten until a dead-rubber loss to Switzerland, are modest favorites with Jonathan David in hot form, while South Africa reach a first-ever World Cup knockout on the back of a resilient defense. A 1-0 backs Canada's edge in what should be a cagey opener where the draw is live, with Alphonso Davies' fitness the swing factor.</div>
+  <div class="teaminfo">
+    <div class="col home">
+      <div class="forms">
+        <span class="chip w" title="1-0 vs South Korea, Jun 24 (World Cup)">W</span><span class="chip d" title="1-1 vs Czechia, Jun 18 (World Cup)">D</span><span class="chip l" title="0-2 vs Mexico, Jun 11 (World Cup)">L</span><span class="chip d" title="1-1 vs Jamaica, Jun 2026 (friendly, behind closed doors)">D</span><span class="chip d" title="0-0 vs Nicaragua, May 29 (friendly)">D</span>
+      </div>
+      <ul>
+        <li>Runners-up in Group A behind Mexico; into the knockouts for the very first time</li>
+        <li class="inj">Teboho Mokoena returns from a one-match suspension; no fresh injuries reported for Hugo Broos</li>
+        <li>Coached by Belgian Hugo Broos; goalkeeper Ronwen Williams, Lyle Foster, Percy Tau and Themba Zwane lead a largely home-based side</li>
+        <li>Beat South Korea 1-0 to pip them to second after a draw with Czechia and an opening loss to Mexico</li>
+        <li class="triv">This is South Africa's first World Cup knockout appearance, having gone out in the group as hosts in 2010</li>
+      </ul>
+    </div>
+    <div class="col">
+      <div class="forms">
+        <span class="chip l" title="1-2 vs Switzerland, Jun 24 (World Cup)">L</span><span class="chip w" title="6-0 vs Qatar, Jun 18 (World Cup)">W</span><span class="chip d" title="1-1 vs Bosnia & Herzegovina, Jun 12 (World Cup)">D</span><span class="chip d" title="1-1 vs Republic of Ireland, Jun 5 (friendly)">D</span><span class="chip w" title="2-0 vs Uzbekistan, Jun 1 (friendly)">W</span>
+      </div>
+      <ul>
+        <li>Runners-up in Group B behind Switzerland; past the group stage for the first time in their history</li>
+        <li class="inj">Alphonso Davies is still managing a hamstring after his ACL recovery and has barely featured; Ismaël Koné is out with a broken leg</li>
+        <li>Coached by Jesse Marsch; Jonathan David, in red-hot form, leads with Cyle Larin, Tajon Buchanan and Stephen Eustáquio</li>
+        <li>Sealed a first-ever World Cup win 6-0 over nine-man Qatar before a dead-rubber loss to Switzerland</li>
+        <li class="triv">Jonathan David scored a hat-trick against Qatar, the first by a Canadian man at a World Cup</li>
+      </ul>
+    </div>
+  </div>
+</div>
+
 <footer>
-  Predictions are mine, sanity-checked against the quoted 1X2 markets (implied probabilities include the bookmaker margin, so they sum to over 100%). Form strips: hover a chip for opponent and score; friendlies count, penalty-shootout results count as regulation draws, and World Cup matchday games are marked in the tooltips. This is the final group round, so the stakes are spelled out per card. Tonight into Saturday (Groups I, H, G): France and Norway are both already through and meet to decide Group I, while Spain (Group H) and Egypt (Group G) lead but the second spots and best-third places are open, with Uruguay, Cape Verde, Saudi Arabia, Iran, Belgium, New Zealand, Senegal and Iraq all chasing a result. Saturday into Sunday (Groups L, K, J): England and Ghana lead Group L with Croatia chasing, Colombia and Portugal are both through and decide Group K, and Argentina have already won Group J, leaving Austria and Algeria in a winner-takes-second shootout. Lineups firm up about an hour before kickoff, so a few items are worth a matchday check: France without head coach Didier Deschamps (bereavement, with Guy Stéphan deputizing), Uruguay's injured Ronald Araújo and Giorgian de Arrascaeta, Senegal's injured goalkeeper Édouard Mendy, Cape Verde's suspended Sidny Lopes, Belgium's suspended Nathan Ngoy, England's fitness doubts around Saka, Rashford and Reece James plus Declan Rice's booking, and Algeria's injured top scorer Mohamed Amoura. Several already-qualified sides (the USA aside, France, Spain, England, Argentina, Portugal and Colombia) are likely to rotate in dead or near-dead rubbers. Kickoff note: every game starts on the half- or full hour; tonight the Group I games run at 21:00 Friday, Group H at 02:00 Berlin Saturday and Group G at 05:00 Berlin Saturday, then Saturday into Sunday the Group L games run at 23:00 Saturday, Group K at 01:30 Berlin Sunday and Group J at 04:00 Berlin Sunday. The two games in each group kick off simultaneously. A few older warm-up and qualifying results in the last-five strips (notably some spring 2026 friendlies and the autumn-2025 qualifiers) are best-available from results databases. Sources: ESPN, CBS Sports, FOX Sports, bet365, FanDuel, BetMGM, DraftKings, Oddschecker, FotMob, FIFA.com, Sky Sports, kicker. Data pulled June 26, 2026 (morning, Berlin); all twelve cards above are still to be played. Say "update the WC dashboard" to refresh.
+  Predictions are mine, sanity-checked against the quoted 1X2 markets (implied probabilities include the bookmaker margin, so they sum to over 100%). Form strips: hover a chip for opponent and score; friendlies count, penalty-shootout results count as regulation draws, and World Cup matchday games are marked in the tooltips. Tonight into Sunday the group stage signs off (Groups L, K, J): England and Ghana lead Group L with Croatia needing a win to overtake them; Colombia and Portugal are both through and decide Group K; and Argentina have already won Group J, leaving Austria and Algeria in a winner-takes-second shootout where, oddly, the runner-up looks set to draw Spain in the round of 32. The two games in each group kick off simultaneously. Then the knockouts begin Sunday evening with a single tie, Canada against South Africa in Los Angeles, the only Round-of-32 game that needs no input from the final group results. Lineups firm up about an hour before kickoff, so a few items are worth a matchday check: England without Reece James and Tino Livramento (Saka and Rashford managed, Declan Rice a booking from suspension), Ghana's goalkeeper Ati-Zigi out with Yirenkyi and Iñaki Williams on bookings, Portugal's doubtful Tomás Araújo, Algeria's injured top scorer Mohamed Amoura, Austria's doubtful Paul Wanner and Stefan Posch, and Canada's Alphonso Davies still short of fitness. Already-qualified sides (England, Argentina, Portugal and Colombia) are likely to rotate in dead or near-dead rubbers. Kickoff note: the Group L games run at 23:00 Berlin Saturday, Group K at 01:30 and Group J at 04:00 Berlin Sunday, then the Round-of-32 opener at 21:00 Berlin Sunday. A few older warm-up results in the last-five strips (some spring 2026 friendlies, and a behind-closed-doors South Africa-Jamaica game) are best-available from results databases. Sources: ESPN, CBS Sports, FOX Sports, bet365, FanDuel, BetMGM, DraftKings, Oddschecker, FotMob, FIFA.com, Sky Sports, kicker. Data pulled June 27, 2026 (morning, Berlin); all seven cards above are still to be played. Say "update the WC dashboard" to refresh.
 </footer>
 
 </div>

--- a/wc/results.html
+++ b/wc/results.html
@@ -71,7 +71,7 @@
 
 <header>
   <h1>⚽ WM 2026 Results</h1>
-  <div class="sub">Group stage results and standings &middot; matchday 3 underway (Groups A&ndash;F complete) &middot; verified through June 25</div>
+  <div class="sub">Group stage results and standings &middot; matchday 3 nearly done (Groups A&ndash;I complete) &middot; verified through June 26</div>
   <div class="home"><a href="https://www.timwappenhans.com">&larr; timwappenhans.com</a></div>
   <nav class="nav">
     <a href="predictions.html">Predictions</a>
@@ -180,8 +180,17 @@
 <div class="rrow"><span class="grp">D</span><span class="h">Paraguay</span><span class="sc">0 : 0</span><span class="a">Australia</span></div>
 <p class="pending">Groups D, E and F have completed matchday 3. Germany lost 2-1 to Ecuador (Sané 2'; Angulo 9', Plata 77') but still won Group E on goal difference ahead of Ivory Coast, who beat Curaçao 2-0 on a Nicolas Pépé brace (7', 64') to reach the World Cup knockout stage for the first time; Ecuador's comeback sent them through as one of the best third-placed teams. The Netherlands beat Tunisia 3-1 (Skhiri own goal 3', Brobbey 7', Van Hecke 62'; Mastouri 54') to top Group F, while Japan drew 1-1 with Sweden (Maeda 56'; Elanga 62') to take second and Sweden advanced as a best third. In Group D the USA, already group winners, lost 3-2 to Türkiye on Kaan Ayhan's stoppage-time winner (Trusty 3', Berhalter 49'; Güler 10', Kökçü 31', Ayhan 90+8'); Paraguay and Australia drew 0-0, Australia going through second on goal difference with Paraguay into the best-third race. Matchday 3 concludes with Groups G, H and I on June 26, then Groups J, K and L on June 27.</p>
 
+<div class="daybar"><h2>Friday, June 26 &middot; matchday 3 (Groups I, H, G)</h2></div>
+<div class="rrow"><span class="grp">I</span><span class="h">Norway</span><span class="sc">1 : 4</span><span class="a">France</span></div>
+<div class="rrow"><span class="grp">I</span><span class="h">Senegal</span><span class="sc">5 : 0</span><span class="a">Iraq</span></div>
+<div class="rrow"><span class="grp">H</span><span class="h">Uruguay</span><span class="sc">0 : 1</span><span class="a">Spain</span></div>
+<div class="rrow"><span class="grp">H</span><span class="h">Cape Verde</span><span class="sc">0 : 0</span><span class="a">Saudi Arabia</span></div>
+<div class="rrow"><span class="grp">G</span><span class="h">Egypt</span><span class="sc">1 : 1</span><span class="a">Iran</span></div>
+<div class="rrow"><span class="grp">G</span><span class="h">New Zealand</span><span class="sc">1 : 5</span><span class="a">Belgium</span></div>
+<p class="pending">Groups G, H and I have completed matchday 3. France won Group I with a perfect nine points, thrashing Norway 4-1 on Ousmane Dembélé's first-half hat-trick (7', 20', 32'), Désiré Doué adding a late fourth; Thelo Aasgaard replied for Norway, who had a Jørgen Strand Larsen penalty saved by Mike Maignan but still went through second. Senegal hammered ten-man Iraq 5-0, the biggest World Cup win by an African nation (Habib Diarra 4', Ismaïla Sarr 56', Pape Gueye 60', 71', Iliman Ndiaye 82'), to take third and a best-third place; Iraq's Rebin Sulaka was sent off on 13 minutes. Spain won Group H by beating Uruguay 1-0 (Álex Baena 42'), eliminating the two-time champions, while Cape Verde drew 0-0 with Saudi Arabia to clinch a historic second place, becoming the smallest nation ever to reach the World Cup knockout stage. Belgium thrashed New Zealand 5-1 (Trossard 28', 50', De Bruyne 66', Lukaku 86', Saelemaekers 90+4'; Just for New Zealand) to leapfrog Egypt and top Group G; Egypt, held 1-1 by Iran (Saber 5'; Rezaeian 14'), took second after Iran had a stoppage-time winner ruled out for offside by VAR, leaving Iran third in the best-third race. The group stage concludes June 27 with Groups J, K and L.</p>
+
 <h2 class="section">Group standings</h2>
-<p class="note">Played, goal difference, points. Green positions are the current top two (direct qualification); the eight best third-placed teams across all groups also advance. Groups A through F have completed all three games; the other six groups have played two, with matchday 3 finishing June 26 (G, H, I) and June 27 (J, K, L).</p>
+<p class="note">Played, goal difference, points. Green positions are the current top two (direct qualification); the eight best third-placed teams across all groups also advance. Groups A through I have now completed all three games; only Groups J, K and L remain, finishing the group stage June 27.</p>
 
 <div class="standings">
 
@@ -233,28 +242,28 @@
   <tr><td class="pos">4</td><td class="tm">Tunisia</td><td>3</td><td>-10</td><td class="pts">0</td></tr>
   </table></div>
 
-  <div class="grp-card"><h3>Group G</h3>
+  <div class="grp-card"><h3>Group G &middot; final</h3>
   <table class="tbl"><tr><th>#</th><th class="tm">Team</th><th>Pld</th><th>GD</th><th>Pts</th></tr>
-  <tr class="q"><td class="pos">1</td><td class="tm">Egypt</td><td>2</td><td>+2</td><td class="pts">4</td></tr>
-  <tr class="q"><td class="pos">2</td><td class="tm">Iran</td><td>2</td><td>0</td><td class="pts">2</td></tr>
-  <tr><td class="pos">3</td><td class="tm">Belgium</td><td>2</td><td>0</td><td class="pts">2</td></tr>
-  <tr><td class="pos">4</td><td class="tm">New Zealand</td><td>2</td><td>-2</td><td class="pts">1</td></tr>
+  <tr class="q"><td class="pos">1</td><td class="tm">Belgium</td><td>3</td><td>+4</td><td class="pts">5</td></tr>
+  <tr class="q"><td class="pos">2</td><td class="tm">Egypt</td><td>3</td><td>+2</td><td class="pts">5</td></tr>
+  <tr><td class="pos">3</td><td class="tm">Iran</td><td>3</td><td>0</td><td class="pts">3</td></tr>
+  <tr><td class="pos">4</td><td class="tm">New Zealand</td><td>3</td><td>-6</td><td class="pts">1</td></tr>
   </table></div>
 
-  <div class="grp-card"><h3>Group H</h3>
+  <div class="grp-card"><h3>Group H &middot; final</h3>
   <table class="tbl"><tr><th>#</th><th class="tm">Team</th><th>Pld</th><th>GD</th><th>Pts</th></tr>
-  <tr class="q"><td class="pos">1</td><td class="tm">Spain</td><td>2</td><td>+4</td><td class="pts">4</td></tr>
-  <tr class="q"><td class="pos">2</td><td class="tm">Uruguay</td><td>2</td><td>0</td><td class="pts">2</td></tr>
-  <tr><td class="pos">3</td><td class="tm">Cape Verde</td><td>2</td><td>0</td><td class="pts">2</td></tr>
-  <tr><td class="pos">4</td><td class="tm">Saudi Arabia</td><td>2</td><td>-4</td><td class="pts">1</td></tr>
+  <tr class="q"><td class="pos">1</td><td class="tm">Spain</td><td>3</td><td>+5</td><td class="pts">7</td></tr>
+  <tr class="q"><td class="pos">2</td><td class="tm">Cape Verde</td><td>3</td><td>0</td><td class="pts">3</td></tr>
+  <tr><td class="pos">3</td><td class="tm">Uruguay</td><td>3</td><td>-1</td><td class="pts">2</td></tr>
+  <tr><td class="pos">4</td><td class="tm">Saudi Arabia</td><td>3</td><td>-4</td><td class="pts">2</td></tr>
   </table></div>
 
-  <div class="grp-card"><h3>Group I</h3>
+  <div class="grp-card"><h3>Group I &middot; final</h3>
   <table class="tbl"><tr><th>#</th><th class="tm">Team</th><th>Pld</th><th>GD</th><th>Pts</th></tr>
-  <tr class="q"><td class="pos">1</td><td class="tm">France</td><td>2</td><td>+5</td><td class="pts">6</td></tr>
-  <tr class="q"><td class="pos">2</td><td class="tm">Norway</td><td>2</td><td>+4</td><td class="pts">6</td></tr>
-  <tr><td class="pos">3</td><td class="tm">Senegal</td><td>2</td><td>-3</td><td class="pts">0</td></tr>
-  <tr><td class="pos">4</td><td class="tm">Iraq</td><td>2</td><td>-6</td><td class="pts">0</td></tr>
+  <tr class="q"><td class="pos">1</td><td class="tm">France</td><td>3</td><td>+8</td><td class="pts">9</td></tr>
+  <tr class="q"><td class="pos">2</td><td class="tm">Norway</td><td>3</td><td>+1</td><td class="pts">6</td></tr>
+  <tr><td class="pos">3</td><td class="tm">Senegal</td><td>3</td><td>+2</td><td class="pts">3</td></tr>
+  <tr><td class="pos">4</td><td class="tm">Iraq</td><td>3</td><td>-10</td><td class="pts">0</td></tr>
   </table></div>
 
   <div class="grp-card"><h3>Group J</h3>
@@ -284,7 +293,7 @@
 </div>
 
 <footer>
-  Scores cross-checked against ESPN, Opta, CBS Sports, NBC, FIFA.com, Sky Sports, and the Wikipedia group pages. Standings show goal difference and points only for compactness. Groups A, B and C have finished. Switzerland won Group B unbeaten on seven points with Canada second and Bosnia third; Brazil and Morocco both took seven from Group C, Brazil topping it on goal difference (+6 to +2), with Scotland third; Mexico completed a perfect Group A with three clean sheets and nine points, South Africa edging South Korea to second on their head-to-head 1-0 win (both finished -1 goal difference). Bosnia, on four points, are already mathematically one of the eight best third-placed teams; Scotland (3 points, -3) and South Korea (3 points, -1) sit lower in that race and must wait on Groups D through L. Qatar, Czechia and Haiti are eliminated, joining Jordan, Panama, Uzbekistan, Tunisia, Iraq and Senegal. From the earlier rounds, Mexico, the United States, Germany, Argentina, France, Norway and Colombia secured places, with the rest of the groups still to play matchday 3. Data through June 24, 2026 (overnight into June 25, Berlin); matchday 3 continues with Groups D, E and F on June 25, then Groups G, H and I on June 26 and Groups J, K and L on June 27.
+  Scores cross-checked against ESPN, Opta, CBS Sports, NBC, FIFA.com, Sky Sports, and the Wikipedia group pages. Standings show goal difference and points only for compactness. Groups A through I are now complete. France won Group I with a perfect nine points and Norway took second; Spain won Group H and Cape Verde, on three points, took a historic second ahead of the eliminated two-time champions Uruguay; Belgium pipped Egypt to the top of Group G on goal difference, with Iran third. The best-third race is filling up: the four group-stage thirds on four points - Ecuador (E, 0), Sweden (F, 0), Bosnia &amp; Herzegovina (B, -1) and Paraguay (D, -2) - are all effectively through, while the three-point thirds Senegal (I, +2), Iran (G, 0), South Korea (A, -1) and Scotland (C, -3) are competing for the last best-third places and could still be displaced by the thirds from Groups J, K and L. Uruguay (2 points) and the other group fourths are out. Newly eliminated on June 26: Uruguay, Saudi Arabia, Iraq and New Zealand. Data through June 26, 2026 (overnight into June 27, Berlin); the group stage concludes June 27 with Groups J, K and L, after which the eight best third-placed teams are confirmed and the Round of 32 is set.
 </footer>
 
 </div>


### PR DESCRIPTION
Recovery PR: direct `git push origin master` was rejected by the local git relay as non-fast-forward even though the GitHub API and `ls-remote` both report master at 818a50f (this commit's parent), i.e. a clean fast-forward. Publishing the already-verified branch via merge instead.

Changes (three pages; germany.html unchanged, no Germany match since June 25):
- predictions.html: recap of the June 26 slate (Groups I/H/G), record now 35/58; rebuilt for tonight's group-stage finale (Groups L/K/J) plus the first Round-of-32 tie (South Africa vs Canada, June 28, Los Angeles), with refreshed odds, form, and team news.
- results.html: appended the six June 26 results with scorers; Groups G/H/I standings recomputed to final.
- bracket.html: Groups A-I resolved into the Round of 32 slots; third-place and J/K/L slots left provisional until the group stage ends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114u1nu9qJryv3DJkFSDTkF

---
_Generated by [Claude Code](https://claude.ai/code/session_0114u1nu9qJryv3DJkFSDTkF)_